### PR TITLE
Enable multiple test instances

### DIFF
--- a/test/scripts/zbc_test_lib.sh
+++ b/test/scripts/zbc_test_lib.sh
@@ -32,6 +32,7 @@ function zbc_test_init() {
 
     # Store argument
     device=$2
+    device_base=`basename ${device}`
     bin_path=$3
 
     # Test name
@@ -48,7 +49,7 @@ function zbc_test_init() {
     rm -f ${log_file}
 
     # Zone info file
-    zone_info_file="/tmp/${test_name}_zone_info.log"
+    zone_info_file="/tmp/${test_name}_zone_info.${device_base}.log"
     rm -f ${zone_info_file}
 
     # Dump zone info file

--- a/test/zbc_test.sh
+++ b/test/zbc_test.sh
@@ -18,6 +18,7 @@ if [ $# -ne 1 ]; then
 fi
 
 device_file=${1}
+device_base=`basename ${device_file}`
 
 # Check credentials
 if [ $(id -u) -ne 0 ]; then
@@ -25,16 +26,13 @@ if [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
-# Set file names
-log_file=${log_path}/${testname}.log
-
 # Test function
 function zbc_run_test()
 {
     declare -i run_test_ret=0
 
     ZBC_TEST_SUB_SCR_PATH=${ZBC_TEST_SCR_PATH}/${1}
-    ZBC_TEST_SUB_LOG_PATH=${ZBC_TEST_LOG_PATH}/${1}
+    ZBC_TEST_SUB_LOG_PATH=${ZBC_TEST_LOG_PATH}/${device_base}/${1}
 
     if [ ! -d ${ZBC_TEST_SUB_SCR_PATH} ]; then
         echo "Test script directory ${ZBC_TEST_SUB_SCR_PATH} does not exist"


### PR DESCRIPTION
The test scripts were creating files which were being reused
by another test instance to another device. These changes use the
device name as part of the files created by the test harness in
order to create device specific test log files.

Signed-off-by: Adam Manzanares <adam.manzanares@wdc.com>