### PR TITLE
Fake disks capacity not supporting 4K logical sector size.

### DIFF
--- a/lib/zbc_ata.c
+++ b/lib/zbc_ata.c
@@ -1122,8 +1122,9 @@ static int zbc_ata_classify(struct zbc_device *dev)
 			       buf,
 			       sizeof(buf));
 	if (ret != 0) {
-		zbc_error("%s: Get supported capabilities page failed\n",
+		zbc_debug("%s: Get supported capabilities page failed\n",
 			  dev->zbd_filename);
+		ret = -ENXIO;
 		goto out;
 	}
 

--- a/tools/set_write_ptr/zbc_set_write_ptr.c
+++ b/tools/set_write_ptr/zbc_set_write_ptr.c
@@ -69,11 +69,18 @@ usage:
 
 	/* Open device */
 	path = argv[i];
-	ret = zbc_open(path, O_RDONLY, &dev);
+	ret = zbc_open(path, O_RDWR, &dev);
 	if (ret != 0)
 		return 1;
 
 	zbc_get_device_info(dev, &info);
+	if (info.zbd_type != ZBC_DT_FAKE) {
+		fprintf(stderr,
+			"Device %s is not using the fake backend driver\n",
+			path);
+		ret = 1;
+		goto out;
+	}
 
 	printf("Device %s:\n", path);
 	zbc_print_device_info(&info, stdout);

--- a/tools/set_zones/zbc_set_zones.c
+++ b/tools/set_zones/zbc_set_zones.c
@@ -73,9 +73,9 @@ usage:
 	if (i > argc - 3)
 		goto usage;
 
-	/* Open device */
+	/* Open device: only allow fake device backend driver */
 	path = argv[i];
-	ret = zbc_open(path, O_RDONLY, &dev);
+	ret = zbc_open(path, O_RDWR, &dev);
 	if (ret < 0) {
 		if (ret == -ENXIO)
 			fprintf(stderr, "Unsupported device type\n");
@@ -88,6 +88,13 @@ usage:
 
 	/* Get device info */
 	zbc_get_device_info(dev, &info);
+	if (info.zbd_type != ZBC_DT_FAKE) {
+		fprintf(stderr,
+			"The fake backend driver is not in use for device %s\n",
+			path);
+		ret = 1;
+		goto out;
+	}
 
 	printf("Device %s:\n", path);
 	zbc_print_device_info(&info, stdout);


### PR DESCRIPTION
When using fake disks with a drive which has logical sector size of 4K, the capacity calculation when performing a set zones is incorrectly using the 4K sector size instead of 512