### PR TITLE
Fake Report Zones returns previous zone

### DIFF
--- a/lib/zbc_fake.c
+++ b/lib/zbc_fake.c
@@ -522,7 +522,7 @@ static bool zbc_fake_must_report_zone(struct zbc_zone *zone,
 	enum zbc_reporting_options options = ro & (~ZBC_RO_PARTIAL);
 
 	if (zone->zbz_length == 0 ||
-	    zone->zbz_start + zone->zbz_length < start_sector)
+	    zone->zbz_start + zone->zbz_length <= start_sector)
 		return false;
 
 	switch (options) {


### PR DESCRIPTION
Issuing zbc_report_zones to a fake device with the target sector equal to the start lba of a zone will return the zone information one prior the target zone.