### PR TITLE
added test for max open zones = -1 to skip zone resource tests

### DIFF
--- a/test/scripts/01_sk_ascq_check/021.sh
+++ b/test/scripts/01_sk_ascq_check/021.sh
@@ -38,6 +38,11 @@ if [ ${max_open} -ge ${nr_zones} ]; then
     zbc_test_print_not_applicable
 fi
 
+# if max_open == -1 then it is "not reported"
+if [ ${max_open} -eq -1 ]; then
+    zbc_test_print_not_applicable
+fi
+
 # Open zones
 zbc_test_open_nr_zones ${max_open}
 

--- a/test/scripts/01_sk_ascq_check/022.sh
+++ b/test/scripts/01_sk_ascq_check/022.sh
@@ -38,6 +38,11 @@ if [ ${max_open} -ge ${nr_zones} ]; then
     zbc_test_print_not_applicable
 fi
 
+# if max_open == -1 then it is "not reported"
+if [ ${max_open} -eq -1 ]; then
+    zbc_test_print_not_applicable
+fi
+
 # Create closed zones
 declare -i count=0
 for i in `seq $(( ${max_open} + 1 ))`; do

--- a/test/scripts/01_sk_ascq_check/072.sh
+++ b/test/scripts/01_sk_ascq_check/072.sh
@@ -38,6 +38,11 @@ if [ ${max_open} -ge ${nr_zones} ]; then
     zbc_test_print_not_applicable
 fi
 
+# if max_open == -1 then it is "not reported"
+if [ ${max_open} -eq -1 ]; then
+    zbc_test_print_not_applicable
+fi
+
 # Open zones
 zbc_test_open_nr_zones ${max_open}
 


### PR DESCRIPTION
Hi Damien-

Currently, with drives that report max_open_zones = -1, the test runs for a very long time then fails because the drive can open all the zones if desired.

I'd like to add a test to the zone resource test scripts to cover the case where max_open_zones = -1, which is "not reported".  If this parameter is not reported I don't think we can make any assumptions on max open zones, so we should probably skip the test. One other alternative I considered is to try and open all the zones and ensure no error, but I'm not sure every implementation that returns -1 really has NO limit.

Thanks,
-Tim