### PR TITLE
zbc_sg: Add dxfer_len to io_hdr in SG_INIT for iovcnt > 1

### DIFF
--- a/lib/zbc_sg.c
+++ b/lib/zbc_sg.c
@@ -299,9 +299,8 @@ int zbc_sg_vcmd_init(struct zbc_device *dev,
 	} else {
 		cmd->buf = buf;
 		cmd->io_hdr.dxferp = cmd->buf;
-		cmd->io_hdr.dxfer_len = cmd->bufsz;
 	}
-
+        cmd->io_hdr.dxfer_len = cmd->bufsz;
 	cmd->io_hdr.mx_sb_len = ZBC_SG_SENSE_MAX_LENGTH;
 	cmd->io_hdr.sbp = cmd->sense_buf;
 


### PR DESCRIPTION
I had troubles writing with multiple iov buffers to disk and always received EIO. 

Debugging showed that the io hdr host status was not ok `(cmd->io_hdr.host_status != ZBC_SG_DID_OK)` and had the error `ZBC_SG_DID_SOFT_ERROR	0x0b /* The low level driver wants a retry. */`.

For one iov buffer everything worked fine, and I found that dxfer lenght was not set moving this out of the if statement solved the problem. 