### PR TITLE
build: avoid double definition of zbc_log_drv etc.

### DIFF
--- a/lib/zbc.h
+++ b/lib/zbc.h
@@ -177,22 +177,22 @@ static inline void zbc_set_errno(enum zbc_sk sk, enum zbc_asc_ascq asc_ascq)
 /**
  * Block device driver (requires kernel support).
  */
-struct zbc_drv zbc_block_drv;
+extern struct zbc_drv zbc_block_drv;
 
 /**
  * ZAC (ATA) device driver (uses SG_IO).
  */
-struct zbc_drv zbc_ata_drv;
+extern struct zbc_drv zbc_ata_drv;
 
 /**
  * ZBC (SCSI) device driver (uses SG_IO).
  */
-struct zbc_drv zbc_scsi_drv;
+extern struct zbc_drv zbc_scsi_drv;
 
 /**
  * ZBC emulation driver (file or block device).
  */
-struct zbc_drv zbc_fake_drv;
+extern struct zbc_drv zbc_fake_drv;
 
 #define container_of(ptr, type, member) \
     ((type *)((char *)(ptr)-(unsigned long)(&((type *)0)->member)))
@@ -266,7 +266,7 @@ enum {
 /**
  * Library log level.
  */
-int zbc_log_level;
+extern int zbc_log_level;
 
 #define zbc_print(stream,format,args...)		\
 	do {						\


### PR DESCRIPTION
When -fno-common is in use, what compiler writers are trying to make
a standard, libzbc fails to build.

$ make V=1
Making all in .
make[1]: Entering directory '/home/jengelh/obs/zu/hardware/libzbc/libzbc'
/bin/sh ./libtool  --tag=CC   --mode=link gcc  -fPIC -fno-common -O2 -g -pthread -Wl,--version-script,./exports -release '5.8.5'  -o libzbc.la -rpath /usr/lib lib/libzbc_la-zbc.lo lib/libzbc_la-zbc_block.lo lib/libzbc_la-zbc_sg.lo lib/libzbc_la-zbc_scsi.lo lib/libzbc_la-zbc_ata.lo lib/libzbc_la-zbc_fake.lo
libtool: link: gcc -shared  -fPIC -DPIC  lib/.libs/libzbc_la-zbc.o lib/.libs/libzbc_la-zbc_block.o lib/.libs/libzbc_la-zbc_sg.o lib/.libs/libzbc_la-zbc_scsi.o lib/.libs/libzbc_la-zbc_ata.o lib/.libs/libzbc_la-zbc_fake.o    -O2 -g -pthread -Wl,--version-script -Wl,./exports   -pthread -Wl,-soname -Wl,libzbc-5.8.5.so -o .libs/libzbc-5.8.5.so
/usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: lib/.libs/libzbc_la-zbc_block.o:/home/jengelh/obs/zu/hardware/libzbc/libzbc/lib/zbc.h:269: multiple definition of `zbc_log_level'; lib/.libs/libzbc_la-zbc.o:/home/jengelh/obs/zu/hardware/libzbc/libzbc/lib/zbc.h:269: first defined here
/usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: lib/.libs/libzbc_la-zbc_block.o:/home/jengelh/obs/zu/hardware/libzbc/libzbc/lib/zbc.h:195: multiple definition of `zbc_fake_drv'; lib/.libs/libzbc_la-zbc.o:/home/jengelh/obs/zu/hardware/libzbc/libzbc/lib/zbc.h:195: first defined here

References: https://bugzilla.suse.com/show_bug.cgi?id=1160244