### PR TITLE
configure is not respecting my chosen CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_ARG_ENABLE(debug,
     [  --enable-debug          Compile with "-g" option],
     [DBGCFLAGS="-g"],
     [DBGCFLAGS="-O2"])
-CFLAGS="$CFLAGS $DBGCFLAGS"
+CFLAGS="$DBGCFLAGS $CFLAGS"
 
 AC_PROG_CC
 AC_PROG_INSTALL

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -5,7 +5,6 @@
 # Copyright (c) 2020 Western Digital Corporation or its affiliates.
 
 AM_CFLAGS = \
-	$(CFLAGS) \
         -Wall -Wextra -Wno-unused-parameter \
         -I$(top_srcdir)/include
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -7,7 +7,6 @@
 SUBDIRS = . $(subdirs)
 
 AM_CFLAGS = \
-	$(CFLAGS) \
         -Wall -Wextra -Wno-unused-parameter \
         -I$(top_srcdir)/include
 

--- a/tools/gui/Makefile.am
+++ b/tools/gui/Makefile.am
@@ -15,7 +15,7 @@ gzbc_SOURCES = \
 	gui/gzbc_if_dev.c \
 	gui/gzbc.h
 
-gzbc_CFLAGS = $(CFLAGS) $(GTK_CFLAGS)
+gzbc_CFLAGS = $(AM_CFLAGS) $(GTK_CFLAGS)
 gzbc_LDADD = $(libzbc_ldadd) $(GTK_LIBS) -lpthread
 
 dist_man8_MANS += gui/gzbc.8

--- a/tools/viewer/Makefile.am
+++ b/tools/viewer/Makefile.am
@@ -16,7 +16,7 @@ gzviewer_SOURCES = \
 	viewer/gzviewer_if.c \
 	viewer/gzviewer.h
 
-gzviewer_CFLAGS = $(CFLAGS) $(GTK_CFLAGS)
+gzviewer_CFLAGS = $(AM_CFLAGS) $(GTK_CFLAGS)
 gzviewer_LDADD = $(libzbc_ldadd) $(GTK_LIBS)
 
 dist_man8_MANS += viewer/gzviewer.8


### PR DESCRIPTION
When invoking `./configure CFLAGS=-O3`, libzbc's configure.ac would tack on -O2, nullifying my request. Not good.

-O3/-O2 also makes a repeated appearance in the build log, which points to problems in the command line construction, hereby fixed.